### PR TITLE
update: ヒートマップの色分け閾値を調整

### DIFF
--- a/src/components/practice/PracticeContributionGraph.tsx
+++ b/src/components/practice/PracticeContributionGraph.tsx
@@ -137,7 +137,7 @@ const PracticeContributionGraph: React.FC<PracticeContributionGraphProps> = ({
             values={contributions}
             classForValue={(value) => {
               if (!value || value.count === 0) return 'color-empty';
-              return `color-scale-${Math.min(4, Math.floor(value.count / 3))}`;
+              return `color-scale-${Math.min(4, Math.floor(value.count / 25))}`;
             }}
             tooltipDataAttrs={(value: ReactCalendarHeatmapValue<string> | undefined) => {
               if (!value || !value.date) return {};

--- a/src/components/practice/UserContributionHeatmap.tsx
+++ b/src/components/practice/UserContributionHeatmap.tsx
@@ -163,7 +163,7 @@ const UserContributionHeatmap: React.FC<UserContributionHeatmapProps> = ({
               values={contributions}
               classForValue={(value) => {
                 if (!value || value.count === 0) return 'color-empty';
-                return `color-scale-${Math.min(4, Math.floor(value.count / 3))}`;
+                return `color-scale-${Math.min(4, Math.floor(value.count / 25))}`;
               }}
               tooltipDataAttrs={(value: any) => {
                 if (!value || !value.date) return {};


### PR DESCRIPTION
* PracticeContributionGraph と UserContributionHeatmap コンポーネントにおいて、コントリビューションの色分け閾値を変更
* カウント値を3で割っていたものを25で割るように修正し、より適切な色分けを実現